### PR TITLE
:bug: Enforce authentication for private Shiny apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+## Overview
+
+This repository runs a Docker Compose stack that combines Django authentication, Nginx routing, MariaDB, and two Shiny Server runtimes for different R versions.
+
+- Start from [README.md](README.md) for environment bootstrap and deployment steps.
+- The stack definition is in [docker-compose.yml](docker-compose.yml).
+- Django code lives in [django-data/shiny](django-data/shiny).
+- Nginx auth and proxy rules live in [nginx-conf.d/nginx-default.conf](nginx-conf.d/nginx-default.conf).
+- Shiny server configuration lives in [shiny/shiny-server.conf](shiny/shiny-server.conf).
+- R applications live in [shiny-apps](shiny-apps).
+
+## Working Rules
+
+- Run project commands from the repository root.
+- Prefer targeted changes. Do not modify [mysql-data](mysql-data) or [renv-cache](renv-cache) unless the task is explicitly about local data or R package cache state.
+- Link to existing docs instead of duplicating them. The repo-level README is the primary human-facing setup guide.
+- Keep changes consistent with the current split between Django auth logic, Nginx routing, and Shiny apps.
+
+## Architecture
+
+- `nginx` is the public entrypoint and proxies Django plus both Shiny runtimes; see [nginx-conf.d/nginx-default.conf](nginx-conf.d/nginx-default.conf).
+- `uwsgi` serves the Django project from [django-data/shiny](django-data/shiny) using settings in [django-data/shiny/shiny/settings.py](django-data/shiny/shiny/settings.py).
+- `db` is MariaDB initialized by [docker-entrypoint-initdb.d/01-create_database.sh](docker-entrypoint-initdb.d/01-create_database.sh).
+- `shiny-4.0` and `shiny-4.5` both mount [shiny-apps](shiny-apps), and app URLs are version-prefixed.
+
+## Django Conventions
+
+- The main app is [serve](django-data/shiny/serve) and the core model is [django-data/shiny/serve/models.py](django-data/shiny/serve/models.py).
+- `ShinyApp.location` must start with `/shiny-{r_version}/`; this is validated in the model and is part of the routing contract.
+- Access control is enforced in two places and changes usually need to stay aligned:
+  - page rendering in [django-data/shiny/serve/views.py](django-data/shiny/serve/views.py)
+  - Nginx subrequest authorization in the `auth` view in [django-data/shiny/serve/views.py](django-data/shiny/serve/views.py)
+- URL patterns are defined in [django-data/shiny/shiny/urls.py](django-data/shiny/shiny/urls.py).
+- Django dependencies and formatter/linter settings are in [uwsgi/pyproject.toml](uwsgi/pyproject.toml).
+
+## Commands Agents Should Prefer
+
+The safest way to run project code is through Docker Compose because Django expects MariaDB service names and env vars from `.env`.
+
+- Start stack: `docker compose up -d`
+- Build images: `docker compose build`
+- Run Django checks: `docker compose run --rm -u $(id -u):www-data uwsgi python manage.py check`
+- Run migrations: `docker compose run --rm -u $(id -u):www-data uwsgi python manage.py migrate`
+- Run tests: `docker compose run --rm -u $(id -u):www-data uwsgi pytest`
+
+If the task is limited to Python formatting or static analysis, inspect [uwsgi/pyproject.toml](uwsgi/pyproject.toml) before introducing new tooling.
+
+## Environment Pitfalls
+
+- A local `.env` file is required for most runtime commands; see [README.md](README.md).
+- Permissions on [django-data/shiny/media](django-data/shiny/media) and thumbnails commonly need fixing after setup; follow the commands in [README.md](README.md).
+- R package behavior depends on the mounted [renv-cache](renv-cache) and the app files in [shiny-apps](shiny-apps).
+- Nginx forwards the original URI through `X-Original-URI`; changes to auth or routing should be checked against [nginx-conf.d/nginx-default.conf](nginx-conf.d/nginx-default.conf) and [django-data/shiny/serve/views.py](django-data/shiny/serve/views.py).
+
+## When Extending Instructions
+
+Create more specific instruction files only if repeated work emerges in one of these areas:
+
+- Django model/view changes under [django-data/shiny/serve](django-data/shiny/serve)
+- container or proxy changes under [docker-compose.yml](docker-compose.yml), [nginx-conf.d](nginx-conf.d), or [shiny](shiny)
+- Shiny app authoring conventions under [shiny-apps](shiny-apps)

--- a/django-data/shiny/serve/tests/test_views.py
+++ b/django-data/shiny/serve/tests/test_views.py
@@ -77,6 +77,16 @@ class ShinyAppViewTestCase(BaseMixin, TestCase):
 
         self.assertEqual(response.status_code, 200)
 
+    def test_get_private_app_anonymous_user(self):
+        url = reverse("shinyapp", kwargs={"slug": "shiny-text"})
+
+        # Anonymous users must not trigger server errors.
+        client = Client()
+        response = client.get(url)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
 
 class ShinyAppListViewTestCase(BaseMixin, TestCase):
     def setUp(self):

--- a/django-data/shiny/serve/tests/test_views.py
+++ b/django-data/shiny/serve/tests/test_views.py
@@ -6,6 +6,7 @@ Created on Thu Apr  2 16:40:39 2020
 @author: Paolo Cozzi <paolo.cozzi@ibba.cnr.it>
 """
 
+from django.conf import settings
 from django.test import Client, TestCase
 from django.urls import resolve, reverse
 
@@ -84,8 +85,11 @@ class ShinyAppViewTestCase(BaseMixin, TestCase):
         client = Client()
         response = client.get(url)
 
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/accounts/login/", response.url)
+        self.assertRedirects(
+            response,
+            f"{settings.LOGIN_URL}?next={url}",
+            fetch_redirect_response=False,
+        )
 
 
 class ShinyAppListViewTestCase(BaseMixin, TestCase):

--- a/django-data/shiny/serve/views.py
+++ b/django-data/shiny/serve/views.py
@@ -40,6 +40,10 @@ class ShinyAppView(UserPassesTestMixin, DetailView):
         if shinyapp.is_public:
             return True
 
+        # Anonymous users can only view public apps.
+        if not self.request.user.is_authenticated:
+            return False
+
         # Check if user is directly assigned
         if self.request.user in shinyapp.users.all():
             return True


### PR DESCRIPTION
This pull request adds comprehensive documentation for project architecture and conventions, and improves access control logic and testing for Shiny app views. The most important changes are:

**Documentation improvements:**

* Added a detailed `AGENTS.md` file outlining the repository's architecture, working rules, service conventions, and recommended commands for agents. This will help onboard new developers and clarify project structure and best practices.

**Access control logic:**

* Updated the `test_func` method in `django-data/shiny/serve/views.py` to explicitly prevent anonymous users from accessing private Shiny apps, ensuring only authenticated users can access non-public apps.

**Testing enhancements:**

* Added a test case in `django-data/shiny/serve/tests/test_views.py` to verify that anonymous users are redirected to the login page when attempting to access a private app, preventing server errors and confirming correct access control behavior.